### PR TITLE
fix (performance) improve performance of FseqLoader

### DIFF
--- a/mcu/include/util/FseqLoader.h
+++ b/mcu/include/util/FseqLoader.h
@@ -14,6 +14,8 @@
 
 #include "logging/Logger.h"
 
+#include "FastLED.h"
+
 namespace TesLight
 {
 	class FseqLoader
@@ -37,23 +39,17 @@ namespace TesLight
 			uint16_t reserved;
 		};
 
-		struct FseqPixel
-		{
-			uint8_t red;
-			uint8_t green;
-			uint8_t blue;
-		};
-
 		FseqLoader(FS *fileSystem);
 		~FseqLoader();
 
 		bool loadFromFile(const String fileName);
-		bool hasNextPixel();
+
+		size_t available();
 		void moveToStart();
 		void close();
 
 		FseqHeader getHeader();
-		FseqPixel getNextPixelFromStream();
+		bool readPixelbuffer(CRGB *pixelBuffer, const size_t bufferSize);
 
 	private:
 		FS *fileSystem;

--- a/mcu/src/configuration/Configuration.cpp
+++ b/mcu/src/configuration/Configuration.cpp
@@ -118,7 +118,7 @@ void TesLight::Configuration::loadDefaults()
 		this->ledConfig[i].type = 0;
 		this->ledConfig[i].speed = 50;
 		this->ledConfig[i].offset = 10;
-		this->ledConfig[i].brightness = 25;
+		this->ledConfig[i].brightness = 50;
 		this->ledConfig[i].reverse = false;
 		this->ledConfig[i].fadeSpeed = 5;
 		for (uint8_t j = 0; j < NUM_ANIMATOR_CUSTOM_FIELDS; j++)

--- a/mcu/src/led/animator/FseqAnimator.cpp
+++ b/mcu/src/led/animator/FseqAnimator.cpp
@@ -74,21 +74,34 @@ void TesLight::FseqAnimator::render()
 		return;
 	}
 
-	for (uint16_t i = 0; i < this->pixelCount; i++)
+	if (this->fseqLoader->available() < this->pixelCount)
 	{
-		if (!this->fseqLoader->hasNextPixel() && this->loop)
+		if (this->loop)
 		{
 			this->fseqLoader->moveToStart();
 		}
-
-		const TesLight::FseqLoader::FseqPixel fseqPixel = this->fseqLoader->getNextPixelFromStream();
-		if (!this->reverse)
-		{
-			this->pixels[i].setRGB(fseqPixel.red, fseqPixel.green, fseqPixel.blue);
-		}
 		else
 		{
-			this->pixels[(this->pixelCount - 1) - i].setRGB(fseqPixel.red, fseqPixel.green, fseqPixel.blue);
+			return;
+		}
+	}
+
+	if (!this->fseqLoader->readPixelbuffer(this->pixels, this->pixelCount))
+	{
+		for (uint16_t i = 0; i < this->pixelCount; i++)
+		{
+			this->pixels[i] = CRGB::Black;
+		}
+	}
+
+	if (this->reverse)
+	{
+
+		for (uint16_t i = 0, j = this->pixelCount - 1; i < j; i++, j--)
+		{
+			CRGB temp = this->pixels[i];
+			this->pixels[i] = this->pixels[j];
+			this->pixels[j] = temp;
 		}
 	}
 

--- a/mcu/src/main.cpp
+++ b/mcu/src/main.cpp
@@ -362,8 +362,11 @@ void setup()
 		TesLight::Logger::log(TesLight::Logger::LogLevel::WARN, SOURCE_LOCATION, F("Failed to create WiFi network. Continuing without WiFi network. The REST API might be inaccessible."));
 	}
 
-	TesLight::Logger::log(TesLight::Logger::LogLevel::INFO, SOURCE_LOCATION, F("TesLight initialized successfully, going into work mode."));
+	TesLight::Logger::log(TesLight::Logger::LogLevel::INFO, SOURCE_LOCATION, F("Initialize timers."));
 	initializeTimers();
+	TesLight::Logger::log(TesLight::Logger::LogLevel::INFO, SOURCE_LOCATION, F("Timers initialized."));
+
+	TesLight::Logger::log(TesLight::Logger::LogLevel::INFO, SOURCE_LOCATION, F("TesLight initialized successfully, going into work mode."));
 }
 
 /**

--- a/mcu/src/util/FseqLoader.cpp
+++ b/mcu/src/util/FseqLoader.cpp
@@ -88,14 +88,13 @@ bool TesLight::FseqLoader::loadFromFile(const String fileName)
 }
 
 /**
- * @brief Return if there is another pixel available.
- * @return true when data is available
- * @return false when the end of the file is reached
+ * @brief Return the number of remaining pixels in the file.
+ * @return size_t number of pixels available to read
  */
-bool TesLight::FseqLoader::hasNextPixel()
+size_t TesLight::FseqLoader::available()
 {
-	TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("Check if there is another pixel available in the fseq file."));
-	return this->file ? this->file.available() >= 3 : false;
+	TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("Get number of pixels available in fseq animation file."));
+	return this->file ? this->file.available() / 3 : 0;
 }
 
 /**
@@ -137,28 +136,26 @@ TesLight::FseqLoader::FseqHeader TesLight::FseqLoader::getHeader()
 }
 
 /**
- * @brief Read the next pixel from the stream.
- * @return {@link TesLight::FseqLoader::FseqPixel} containing the next color value
+ * @brief Read a buffer of pixels from the stream.
+ * @param pixelBuffer pointer to a {@link CRGB buffer} for the pixel data
+ * @param bufferSize number of pixels in the buffer/number of pixels to be read from the stream
+ * @return true when read successfully
+ * @return false when there was an error
  */
-TesLight::FseqLoader::FseqPixel TesLight::FseqLoader::getNextPixelFromStream()
+bool TesLight::FseqLoader::readPixelbuffer(CRGB *pixelBuffer, const size_t bufferSize)
 {
-	TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("Read next pixel from the fseq file."));
-	TesLight::FseqLoader::FseqPixel pixel;
-	if (this->file && this->file.available() >= 3)
+	TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("Read pixel buffer from the fseq file."));
+	if (this->file && this->available() >= bufferSize)
 	{
-		this->file.readBytes((char *)&pixel.red, 1);
-		this->file.readBytes((char *)&pixel.green, 1);
-		this->file.readBytes((char *)&pixel.blue, 1);
-	}
-	else
-	{
-		pixel.red = 0;
-		pixel.green = 0;
-		pixel.blue = 0;
+		if (this->file.read((uint8_t *)pixelBuffer, bufferSize * 3) == bufferSize * 3)
+		{
+			TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("Pixel read from the fseq file."));
+			return true;
+		}
 	}
 
-	TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("Pixel read from the fseq file."));
-	return pixel;
+	TesLight::Logger::log(TesLight::Logger::LogLevel::WARN, SOURCE_LOCATION, F("Failed to read pixel buffer from fseq file."));
+	return false;
 }
 
 /**


### PR DESCRIPTION
closes #23

Performance of the `FseqLoader` and `FseqAnimator` is now improved by reading the pixels directly into the pixel buffer instead of reading single pixels one by one.