### PR TITLE
feat (api) access log via rest api

### DIFF
--- a/mcu/include/server/LogEndpoint.h
+++ b/mcu/include/server/LogEndpoint.h
@@ -1,0 +1,37 @@
+/**
+ * @file LogEndpoint.h
+ * @author TheRealKasumi
+ * @brief Contains a REST endpoint to manage the log file of the TesLight controller.
+ *
+ * @copyright Copyright (c) 2022
+ *
+ */
+#ifndef LOG_ENDPOINT_H
+#define LOG_ENDPOINT_H
+
+#include <FS.h>
+#include <esp_task_wdt.h>
+
+#include "configuration/SystemConfiguration.h"
+#include "server/RestEndpoint.h"
+#include "logging/Logger.h"
+
+namespace TesLight
+{
+	class LogEndpoint : public RestEndpoint
+	{
+	public:
+		static void begin(FS *_fileSystem);
+
+	private:
+		LogEndpoint();
+
+		static FS *fileSystem;
+
+		static void getLogSize(AsyncWebServerRequest *request);
+		static void getLog(AsyncWebServerRequest *request);
+		static void clearLog(AsyncWebServerRequest *request);
+	};
+}
+
+#endif

--- a/mcu/src/logging/Logger.cpp
+++ b/mcu/src/logging/Logger.cpp
@@ -104,7 +104,7 @@ void TesLight::Logger::log(const TesLight::Logger::LogLevel logLevel, const char
 	{
 
 		File logFile = fileSystem->open(fileName, FILE_APPEND);
-		if (!logFile)
+		if (!logFile || logFile.isDirectory())
 		{
 			return;
 		}
@@ -170,6 +170,7 @@ void TesLight::Logger::clearLog()
 	}
 
 	fileSystem->remove(fileName);
+	TesLight::Logger::log(TesLight::Logger::LogLevel::INFO, SOURCE_LOCATION, F("Log file was cleared."));
 }
 
 /**

--- a/mcu/src/main.cpp
+++ b/mcu/src/main.cpp
@@ -26,6 +26,7 @@
 #include "server/LedConfigurationEndpoint.h"
 #include "server/WiFiConfigurationEndpoint.h"
 #include "server/FseqEndpoint.h"
+#include "server/LogEndpoint.h"
 
 #define MAX_ULONG_VALUE 0xffffffffffffffff
 
@@ -206,16 +207,18 @@ void initializeWebServer()
 void initializeRestApi()
 {
 	TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("Initialize REST API."));
-	TesLight::ConnectionTestEndpoint::init(webServer, "/api/");
+	TesLight::ConnectionTestEndpoint::init(webServer, F("/api/"));
 	TesLight::ConnectionTestEndpoint::begin();
-	TesLight::SystemConfigurationEndpoint::init(webServer, "/api/");
+	TesLight::SystemConfigurationEndpoint::init(webServer, F("/api/"));
 	TesLight::SystemConfigurationEndpoint::begin(configuration, systemConfigChanged);
-	TesLight::LedConfigurationEndpoint::init(webServer, "/api/");
+	TesLight::LedConfigurationEndpoint::init(webServer, F("/api/"));
 	TesLight::LedConfigurationEndpoint::begin(configuration, ledConfigChanged);
-	TesLight::WiFiConfigurationEndpoint::init(webServer, "/api/");
+	TesLight::WiFiConfigurationEndpoint::init(webServer, F("/api/"));
 	TesLight::WiFiConfigurationEndpoint::begin(configuration, wifiConfigChanged);
-	TesLight::FseqEndpoint::init(webServer, "/api/");
+	TesLight::FseqEndpoint::init(webServer, F("/api/"));
 	TesLight::FseqEndpoint::begin(&SD);
+	TesLight::LogEndpoint::init(webServer, F("/api/"));
+	TesLight::LogEndpoint::begin(&SD);
 	TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("REST API initialized."));
 }
 

--- a/mcu/src/server/FseqEndpoint.cpp
+++ b/mcu/src/server/FseqEndpoint.cpp
@@ -67,7 +67,7 @@ void TesLight::FseqEndpoint::postFseq(AsyncWebServerRequest *request)
  */
 void TesLight::FseqEndpoint::postFseqBody(AsyncWebServerRequest *request, uint8_t *data, const size_t len, const size_t index, const size_t total)
 {
-	const String fileName = request->arg("fileName");
+	const String fileName = request->arg(F("fileName"));
 	if (fileName.length() == 0)
 	{
 		TesLight::Logger::log(TesLight::Logger::LogLevel::WARN, SOURCE_LOCATION, F("Received request to upload a new fseq file but the fileName parameter is empty."));
@@ -119,7 +119,7 @@ void TesLight::FseqEndpoint::deleteFseq(AsyncWebServerRequest *request)
 {
 	TesLight::Logger::log(TesLight::Logger::LogLevel::INFO, SOURCE_LOCATION, F("Received request to delete a fseq file."));
 
-	const String fileName = request->arg("fileName");
+	const String fileName = request->arg(F("fileName"));
 	if (fileName.length() == 0)
 	{
 		TesLight::Logger::log(TesLight::Logger::LogLevel::WARN, SOURCE_LOCATION, F("Failed to delete file because fileName parameter is empty."));
@@ -129,14 +129,14 @@ void TesLight::FseqEndpoint::deleteFseq(AsyncWebServerRequest *request)
 
 	if (!fileSystem->exists(FSEQ_DIRECTORY + (String)F("/") + fileName))
 	{
-		TesLight::Logger::log(TesLight::Logger::LogLevel::INFO, SOURCE_LOCATION, (String)F("File ") + FSEQ_DIRECTORY + F("/") + fileName + F(" was not found."));
+		TesLight::Logger::log(TesLight::Logger::LogLevel::WARN, SOURCE_LOCATION, (String)F("File ") + FSEQ_DIRECTORY + F("/") + fileName + F(" was not found."));
 		request->send(404, F("text/plain"), (String)F("File ") + FSEQ_DIRECTORY + F("/") + fileName + F(" was not found."));
 		return;
 	}
 
 	if (!fileSystem->remove(FSEQ_DIRECTORY + (String)F("/") + fileName))
 	{
-		TesLight::Logger::log(TesLight::Logger::LogLevel::INFO, SOURCE_LOCATION, F("Failed to delete file."));
+		TesLight::Logger::log(TesLight::Logger::LogLevel::WARN, SOURCE_LOCATION, F("Failed to delete file."));
 		request->send(500, F("text/plain"), F("Failed to delete file."));
 		return;
 	}

--- a/mcu/src/server/LedConfigurationEndpoint.cpp
+++ b/mcu/src/server/LedConfigurationEndpoint.cpp
@@ -82,7 +82,7 @@ void TesLight::LedConfigurationEndpoint::postLedConfig(AsyncWebServerRequest *re
 		request->send(400, F("text/plain"), F("The content type must be \"application/x-www-form-urlencoded\"."));
 		return;
 	}
-	else if (request->arg("data").length() == 0)
+	else if (request->arg(F("data")).length() == 0)
 	{
 		TesLight::Logger::log(TesLight::Logger::LogLevel::WARN, SOURCE_LOCATION, F("There must be a body parameter \"data\" with the base64 encoded LED data."));
 		request->send(400, F("text/plain"), F("There must be a body parameter \"data\" with the base64 encoded LED data."));
@@ -90,7 +90,7 @@ void TesLight::LedConfigurationEndpoint::postLedConfig(AsyncWebServerRequest *re
 	}
 
 	TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("Decoding base64 request."));
-	const String encoded = request->arg("data");
+	const String encoded = request->arg(F("data"));
 	size_t length;
 	uint8_t *decoded = TesLight::Base64Util::decode(encoded, length);
 	if (decoded == nullptr)

--- a/mcu/src/server/LogEndpoint.cpp
+++ b/mcu/src/server/LogEndpoint.cpp
@@ -1,0 +1,144 @@
+/**
+ * @file LogEndpoint.cpp
+ * @author TheRealKasumi
+ * @brief Implementation of a REST endpoint to manage the log of the TesLight controller.
+ *
+ * @copyright Copyright (c) 2022
+ *
+ */
+#include "server/LogEndpoint.h"
+
+// Initialize
+FS *TesLight::LogEndpoint::fileSystem = nullptr;
+
+/**
+ * @brief Add all request handler for this {@link TesLight::RestEndpoint} to the {@link TesLight::WebServer}.
+ */
+void TesLight::LogEndpoint::begin(FS *_fileSystem)
+{
+	TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("Initialize Log Endpoint."));
+	fileSystem = _fileSystem;
+
+	TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("Register Log Endpoints."));
+	getWebServer()->addRequestHandler((getBaseUri() + F("log/size")).c_str(), http_method::HTTP_GET, TesLight::LogEndpoint::getLogSize);
+	getWebServer()->addRequestHandler((getBaseUri() + F("log")).c_str(), http_method::HTTP_GET, TesLight::LogEndpoint::getLog);
+	// TODO: Why delete method isn't working? Bug in library or expected? Until resolved patch is used for deleting... :(
+	getWebServer()->addRequestHandler((getBaseUri() + F("log")).c_str(), http_method::HTTP_PATCH, TesLight::LogEndpoint::clearLog);
+}
+
+/**
+ * @brief Return the size of the log file in bytes.
+ * @param request instance of {@link AsyncWebServerRequest}
+ */
+void TesLight::LogEndpoint::getLogSize(AsyncWebServerRequest *request)
+{
+	TesLight::Logger::log(TesLight::Logger::LogLevel::INFO, SOURCE_LOCATION, F("Received request to get the log size."));
+	TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("Open log file."));
+	File file = fileSystem->open(LOG_FILE_NAME, FILE_READ);
+	if (!file)
+	{
+		TesLight::Logger::log(TesLight::Logger::LogLevel::WARN, SOURCE_LOCATION, F("Failed to open log file."));
+		request->send(500, F("text/plain"), F("Failed to open log file."));
+		return;
+	}
+	else if (file.isDirectory())
+	{
+		TesLight::Logger::log(TesLight::Logger::LogLevel::WARN, SOURCE_LOCATION, F("Failed to open log file because it is a directory."));
+		file.close();
+		request->send(500, F("text/plain"), F("Failed to open log file because it is a directory."));
+		return;
+	}
+
+	TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("Reading log size in bytes and closing file."));
+	const size_t logSize = file.size();
+	file.close();
+
+	TesLight::Logger::log(TesLight::Logger::LogLevel::INFO, SOURCE_LOCATION, F("Sending the response."));
+	request->send(200, F("text/plain"), String(logSize));
+}
+
+/**
+ * @brief Get a section of the log file, determinded by the paremters start and count in bytes.
+ * @param request instance of {@link AsyncWebServerRequest}
+ */
+void TesLight::LogEndpoint::getLog(AsyncWebServerRequest *request)
+{
+	TesLight::Logger::log(TesLight::Logger::LogLevel::INFO, SOURCE_LOCATION, F("Received request to get a section of the log file."));
+	if (request->arg(F("start")).length() == 0 || request->arg(F("count")).length() == 0)
+	{
+		TesLight::Logger::log(TesLight::Logger::LogLevel::WARN, SOURCE_LOCATION, F("The parameters \"start\" and \"count\" must be provided."));
+		request->send(400, F("text/plain"), F("The parameters \"start\" and \"count\" must be provided."));
+		return;
+	}
+
+	TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("Reading start and count parameters."));
+	const size_t start = request->arg(F("start")).toInt();
+	const size_t count = request->arg(F("count")).toInt();
+
+	TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("Open log file."));
+	File file = fileSystem->open(LOG_FILE_NAME, FILE_READ);
+	if (!file)
+	{
+		TesLight::Logger::log(TesLight::Logger::LogLevel::WARN, SOURCE_LOCATION, F("Failed to open log file."));
+		request->send(500, F("text/plain"), F("Failed to open log file."));
+		return;
+	}
+	else if (file.isDirectory())
+	{
+		TesLight::Logger::log(TesLight::Logger::LogLevel::WARN, SOURCE_LOCATION, F("Failed to open log file because it is a directory."));
+		file.close();
+		request->send(500, F("text/plain"), F("Failed to open log file because it is a directory."));
+		return;
+	}
+
+	TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("Reading log size in bytes and closing file."));
+	const size_t logSize = file.size();
+	file.close();
+
+	TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("Checking start and count parameters."));
+	if (start >= logSize || start + count >= logSize)
+	{
+		TesLight::Logger::log(TesLight::Logger::LogLevel::WARN, SOURCE_LOCATION, F("The start or count parameters are invalid."));
+		request->send(400, F("text/plain"), F("The start or count parameters are invalid."));
+		return;
+	}
+
+	TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("Sending chunked response."));
+	AsyncWebServerResponse *response = request->beginChunkedResponse("text/plain", [start, count](uint8_t *buffer, size_t maxLen, size_t index) -> size_t
+																	 {
+		esp_task_wdt_reset();
+		size_t remaining = count - index;
+		if(remaining == 0)
+		{
+			return 0;
+		} 
+		else if(remaining > maxLen) 
+		{
+			remaining  = maxLen;
+		} 
+
+		File file = fileSystem->open(LOG_FILE_NAME, FILE_READ);
+		if (!file)
+		{
+			return 0;
+		}
+
+		file.seek(start + index);
+		size_t readBytes = file.read(buffer, remaining);
+		file.close();
+
+		return readBytes; });
+	request->send(response);
+}
+
+/**
+ * @brief Clear the log file of the controller.
+ * @param request instance of {@link AsyncWebServerRequest}
+ */
+void TesLight::LogEndpoint::clearLog(AsyncWebServerRequest *request)
+{
+	TesLight::Logger::log(TesLight::Logger::LogLevel::INFO, SOURCE_LOCATION, F("Received request to clear the log file."));
+	TesLight::Logger::clearLog();
+	TesLight::Logger::log(TesLight::Logger::LogLevel::INFO, SOURCE_LOCATION, F("Sending the response."));
+	request->send(200, F("text/plain"), F("Log cleared."));
+}

--- a/mcu/src/server/SystemConfigurationEndpoint.cpp
+++ b/mcu/src/server/SystemConfigurationEndpoint.cpp
@@ -71,7 +71,7 @@ void TesLight::SystemConfigurationEndpoint::postSystemConfig(AsyncWebServerReque
 		request->send(400, F("text/plain"), F("The content type must be \"application/x-www-form-urlencoded\"."));
 		return;
 	}
-	else if (request->arg("data").length() == 0)
+	else if (request->arg(F("data")).length() == 0)
 	{
 		TesLight::Logger::log(TesLight::Logger::LogLevel::WARN, SOURCE_LOCATION, F("There must be a body parameter \"data\" with the base64 encoded system data."));
 		request->send(400, F("text/plain"), F("There must be a body parameter \"data\" with the base64 encoded system data."));
@@ -79,7 +79,7 @@ void TesLight::SystemConfigurationEndpoint::postSystemConfig(AsyncWebServerReque
 	}
 
 	TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("Decoding base64 request."));
-	const String encoded = request->arg("data");
+	const String encoded = request->arg(F("data"));
 	size_t length;
 	uint8_t *decoded = TesLight::Base64Util::decode(encoded, length);
 	if (decoded == nullptr)

--- a/mcu/src/server/WiFiConfigurationEndpoint.cpp
+++ b/mcu/src/server/WiFiConfigurationEndpoint.cpp
@@ -73,7 +73,7 @@ void TesLight::WiFiConfigurationEndpoint::postWiFiConfig(AsyncWebServerRequest *
 		request->send(400, F("text/plain"), F("The content type must be \"application/x-www-form-urlencoded\"."));
 		return;
 	}
-	else if (request->arg("data").length() == 0)
+	else if (request->arg(F("data")).length() == 0)
 	{
 		TesLight::Logger::log(TesLight::Logger::LogLevel::WARN, SOURCE_LOCATION, F("There must be a body parameter \"data\" with the base64 encoded WiFi data."));
 		request->send(400, F("text/plain"), F("There must be a body parameter \"data\" with the base64 encoded WiFi data."));
@@ -81,7 +81,7 @@ void TesLight::WiFiConfigurationEndpoint::postWiFiConfig(AsyncWebServerRequest *
 	}
 
 	TesLight::Logger::log(TesLight::Logger::LogLevel::DEBUG, SOURCE_LOCATION, F("Decoding base64 request."));
-	const String encoded = request->arg("data");
+	const String encoded = request->arg(F("data"));
 	size_t length;
 	uint8_t *decoded = TesLight::Base64Util::decode(encoded, length);
 	if (decoded == nullptr)

--- a/postman/TesLight.postman_collection.json
+++ b/postman/TesLight.postman_collection.json
@@ -1,0 +1,385 @@
+{
+	"info": {
+		"_postman_id": "c834c289-81fc-4aea-a654-b4fbe727232e",
+		"name": "TesLight",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "12963851"
+	},
+	"item": [
+		{
+			"name": "Connection Test",
+			"item": [
+				{
+					"name": "Connection Test",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://{{TESLIGHTIP}}/api/connection_test",
+							"protocol": "http",
+							"host": [
+								"{{TESLIGHTIP}}"
+							],
+							"path": [
+								"api",
+								"connection_test"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "WiFi Configuration",
+			"item": [
+				{
+					"name": "Get WiFi Configuration",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://{{TESLIGHTIP}}/api/config/wifi",
+							"protocol": "http",
+							"host": [
+								"{{TESLIGHTIP}}"
+							],
+							"path": [
+								"api",
+								"config",
+								"wifi"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Set WiFi Configuration",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "data",
+									"value": "",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "http://{{TESLIGHTIP}}/api/config/wifi",
+							"protocol": "http",
+							"host": [
+								"{{TESLIGHTIP}}"
+							],
+							"path": [
+								"api",
+								"config",
+								"wifi"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "LED Configuration",
+			"item": [
+				{
+					"name": "Get LED Configuration",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://{{TESLIGHTIP}}/api/config/led",
+							"protocol": "http",
+							"host": [
+								"{{TESLIGHTIP}}"
+							],
+							"path": [
+								"api",
+								"config",
+								"led"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Set LED Configuration",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "data",
+									"value": "",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "http://{{TESLIGHTIP}}/api/config/led",
+							"protocol": "http",
+							"host": [
+								"{{TESLIGHTIP}}"
+							],
+							"path": [
+								"api",
+								"config",
+								"led"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "System Configuration",
+			"item": [
+				{
+					"name": "Get System Configuration",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://{{TESLIGHTIP}}/api/config/system",
+							"protocol": "http",
+							"host": [
+								"{{TESLIGHTIP}}"
+							],
+							"path": [
+								"api",
+								"config",
+								"system"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Set System Configuration",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "data",
+									"value": "",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "http://{{TESLIGHTIP}}/api/config/system",
+							"protocol": "http",
+							"host": [
+								"{{TESLIGHTIP}}"
+							],
+							"path": [
+								"api",
+								"config",
+								"system"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "FSEQ",
+			"item": [
+				{
+					"name": "Get FSEQ List",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://{{TESLIGHTIP}}/api/fseq",
+							"protocol": "http",
+							"host": [
+								"{{TESLIGHTIP}}"
+							],
+							"path": [
+								"api",
+								"fseq"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Upload FSEQ File",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "file",
+							"file": {
+								"src": ""
+							}
+						},
+						"url": {
+							"raw": "http://{{TESLIGHTIP}}/api/fseq?fileName=",
+							"protocol": "http",
+							"host": [
+								"{{TESLIGHTIP}}"
+							],
+							"path": [
+								"api",
+								"fseq"
+							],
+							"query": [
+								{
+									"key": "fileName",
+									"value": ""
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete a FSEQ File",
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"url": {
+							"raw": "http://{{TESLIGHTIP}}/api/fseq?fileName=",
+							"protocol": "http",
+							"host": [
+								"{{TESLIGHTIP}}"
+							],
+							"path": [
+								"api",
+								"fseq"
+							],
+							"query": [
+								{
+									"key": "fileName",
+									"value": ""
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Log",
+			"item": [
+				{
+					"name": "Get Log Size",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://{{TESLIGHTIP}}/api/log/size",
+							"protocol": "http",
+							"host": [
+								"{{TESLIGHTIP}}"
+							],
+							"path": [
+								"api",
+								"log",
+								"size"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Log",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://{{TESLIGHTIP}}/api/log?start=0&count=0",
+							"protocol": "http",
+							"host": [
+								"{{TESLIGHTIP}}"
+							],
+							"path": [
+								"api",
+								"log"
+							],
+							"query": [
+								{
+									"key": "start",
+									"value": "0"
+								},
+								{
+									"key": "count",
+									"value": "0"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Clear Log",
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"url": {
+							"raw": "http://{{TESLIGHTIP}}/api/log",
+							"protocol": "http",
+							"host": [
+								"{{TESLIGHTIP}}"
+							],
+							"path": [
+								"api",
+								"log"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "TESLIGHTIP",
+			"value": "192.168.4.1",
+			"type": "string"
+		}
+	]
+}


### PR DESCRIPTION
closes #21

The TesLight log can now be accessed via the rest api. Also a postman collection was added to the project. The frontend part will be done with the new frontend version.