### PR TITLE
fix locale on Mac

### DIFF
--- a/update-package-tool/.vscode/tasks.json
+++ b/update-package-tool/.vscode/tasks.json
@@ -5,7 +5,7 @@
 			"label": "C/C++: g++.exe build project",
 			"type": "cppbuild",
 			"command": "g++.exe",
-			"args": ["-g", "${workspaceRoot}\\src\\*.cpp", "-o", "${workspaceRoot}\\build\\tupt.exe"],
+			"args": ["-std=c++17", "-g", "${workspaceRoot}\\src\\*.cpp", "-o", "${workspaceRoot}\\build\\tupt.exe"],
 			"group": {
 				"kind": "build",
 				"isDefault": true

--- a/update-package-tool/ReadMe.md
+++ b/update-package-tool/ReadMe.md
@@ -22,11 +22,11 @@ So the decision was made to update everything on the system with a single packag
 ## Build
 
 You can use any C++17 compatible compiler to build this tool.
-I used [g++](https://www.mingw-w64.org/) on Windows.
+I used [gcc](https://www.mingw-w64.org/) on Windows but this tool can also be built on Linux and Mac.
 
 ```sh
 mkdir build
-g++ -g src\*.cpp -o build\tupt.exe
+g++ -std=c++17 -g ./src/*.cpp -o build/tupt.exe
 ```
 
 ## Usage

--- a/update-package-tool/src/main.cpp
+++ b/update-package-tool/src/main.cpp
@@ -30,9 +30,12 @@ int main(int argc, char *argv[])
 {
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
 	_setmode(_fileno(stdout), _O_U16TEXT);
+#elif __APPLE__
+	std::wcout.sync_with_stdio(false);
+	std::wcout.imbue(std::locale("en_US.UTF-8"));
 #else
 	std::wcout.sync_with_stdio(false);
-	std::wcout.imbue(std::locale("en_US.utf8"));
+	std::wcout.imbue(std::locale("en_US.utf-8"));
 #endif
 
 	printHeader();

--- a/update-package-tool/src/main.cpp
+++ b/update-package-tool/src/main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 	std::wcout.imbue(std::locale("en_US.UTF-8"));
 #else
 	std::wcout.sync_with_stdio(false);
-	std::wcout.imbue(std::locale("en_US.utf-8"));
+	std::wcout.imbue(std::locale("en_US.utf8"));
 #endif
 
 	printHeader();


### PR DESCRIPTION
Apple feels very special and is not accepting the `en_US.utf8` locale like (I think) everyone else on this planet does. Instead they only accepts `en_US.UTF-8`. Anyway, it's fixed by adding an exception.

![image](https://user-images.githubusercontent.com/62426919/214641722-49ed5feb-0d65-463d-9784-5484812440ab.png)

Oh and I updated the build commands a little to support ppl who run into problems with it.