### PR TITLE
feat: new light sensor mode: combined on/off switching and automatic dimming using BH1070

### DIFF
--- a/mcu/include/sensor/LightSensor.h
+++ b/mcu/include/sensor/LightSensor.h
@@ -54,7 +54,8 @@ namespace TL
 			AUTO_BRIGHTNESS_ADC = 3,
 			AUTO_ON_OFF_BH1750 = 4,
 			AUTO_BRIGHTNESS_BH1750 = 5,
-			AUTO_ON_OFF_MOTION = 6
+			AUTO_ON_OFF_MOTION = 6,
+			AUTO_ON_OFF_ADC_AUTO_BRIGHTNESS_BH1750 = 7
 		};
 
 		static TL::LightSensor::Error begin();

--- a/mcu/src/server/SystemConfigurationEndpoint.cpp
+++ b/mcu/src/server/SystemConfigurationEndpoint.cpp
@@ -197,10 +197,10 @@ bool TL::SystemConfigurationEndpoint::validateConfiguration(const JsonObject &js
 		return false;
 	}
 
-	if (!TL::SystemConfigurationEndpoint::isInRange(jsonObject[F("lightSensorMode")].as<uint8_t>(), 0, 6))
+	if (!TL::SystemConfigurationEndpoint::isInRange(jsonObject[F("lightSensorMode")].as<uint8_t>(), 0, 7))
 	{
-		TL::Logger::log(TL::Logger::LogLevel::WARN, SOURCE_LOCATION, F("The \"lightSensorMode\" field is invalid. It should be between 0 and 6."));
-		TL::SystemConfigurationEndpoint::sendSimpleResponse(400, F("The \"lightSensorMode\" field is invalid. It should be between 0 and 6."));
+		TL::Logger::log(TL::Logger::LogLevel::WARN, SOURCE_LOCATION, F("The \"lightSensorMode\" field is invalid. It should be between 0 and 7."));
+		TL::SystemConfigurationEndpoint::sendSimpleResponse(400, F("The \"lightSensorMode\" field is invalid. It should be between 0 and 7."));
 		return false;
 	}
 

--- a/ui/public/locales/de/translation.json
+++ b/ui/public/locales/de/translation.json
@@ -80,7 +80,8 @@
       "AutomaticBrightnessADC": "Automatische Helligkeit ADC",
       "AutomaticOnOffBH1750": "Automatisch An/Aus BH1750",
       "AutomaticBrightnessBH1750": "Automatische Helligkeit BH1750",
-      "AutomaticOnOffMPU6050": "Automatisch An/Aus MPU6050"
+      "AutomaticOnOffMPU6050": "Automatisch An/Aus MPU6050",
+      "AutomaticOnOffADCAutomaticBrightnessBH1750": "Automatisch An/Aus ADC + Automatische Helligkeit BH1750"
     },
     "lightSensorThreshold": "Sensor Schwellenwert",
     "loggingAndDebugging": "Protokollierung und Fehlersuche",

--- a/ui/public/locales/en/translation.json
+++ b/ui/public/locales/en/translation.json
@@ -80,7 +80,8 @@
       "AutomaticBrightnessBH1750": "Automatic Brightness BH1750",
       "AutomaticOnOffADC": "Automatic On/Off ADC",
       "AutomaticOnOffBH1750": "Automatic On/Off BH1750",
-      "AutomaticOnOffMPU6050": "Automatic On/Off MPU6050"
+      "AutomaticOnOffMPU6050": "Automatic On/Off MPU6050",
+      "AutomaticOnOffADCAutomaticBrightnessBH1750": "Automatic On/Off ADC + Automatic Brightness BH1750"
     },
     "lightSensorThreshold": "Sensor Threshold",
     "loggingAndDebugging": "Logging and Debugging",

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -41,6 +41,7 @@ enum LightSensorMode {
   AutomaticOnOffBH1750,
   AutomaticBrightnessBH1750,
   AutomaticOnOffMPU6050,
+  AutomaticOnOffADCAutomaticBrightnessBH1750,
 }
 
 enum FanMode {
@@ -256,6 +257,14 @@ const Form = (): JSX.Element => {
         ([, value]) =>
           value !== LightSensorMode.AutomaticOnOffBH1750 ||
           (value === LightSensorMode.AutomaticOnOffBH1750 && hasBH1750),
+      )
+      .filter(
+        ([, value]) =>
+          value !==
+            LightSensorMode.AutomaticOnOffADCAutomaticBrightnessBH1750 ||
+          (value ===
+            LightSensorMode.AutomaticOnOffADCAutomaticBrightnessBH1750 &&
+            hasBH1750),
       );
   };
 
@@ -342,6 +351,7 @@ const Form = (): JSX.Element => {
           {[
             LightSensorMode.AutomaticBrightnessADC,
             LightSensorMode.AutomaticBrightnessBH1750,
+            LightSensorMode.AutomaticOnOffADCAutomaticBrightnessBH1750,
           ].includes(Number(values.system.lightSensorMode)) && (
             <>
               <label className="mb-6 flex flex-col">


### PR DESCRIPTION
This PR aims to implement a new light sensor mode that combines on/off switching using ADC and auto brightness using BH1070. This is especially useful in vehicles that do not have footwell lights.

ToDos:
- [ ] Discuss & implement a similar mode for on/off switching using the motion sensor
- [ ] Refactor code (remove duplicate logic)

#103